### PR TITLE
Rename "nice to have"

### DIFF
--- a/dict/de/de.json
+++ b/dict/de/de.json
@@ -2349,7 +2349,7 @@
     "Low": "Niedrig",
     "Moderate": "Moderat",
     "Must Have": "Must Have",
-    "Nice To Have": "Unwichtig",
+    "Nice To Have": "Nice To Have",
     "Urgent": "Dringend",
     "Me": "Ich",
     "It": "Es",


### PR DESCRIPTION
"Unwichtig" is the translation for "not important", which is not the same as "nice to have".
Changing the translation to the english term because of the lack of a better translation (which is still better than a wrong translation)